### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-#Kill switch
+# Kill switch
 
 A simple bit of javascript to take down a site it is included on.
 
-###Why?
+### Why?
 Despite best efforts, sometimes you just need to take a site down.
 
 * Your client has decided not to pay you. 
 * A site you have made has been plagiarised.
 * You feel like being a bit of a dick.
 
-###How it works
+### How it works
 The small bit of JavaScript calls in another JavaScript file, which can then do anything you need, for example: 
 
 * Remove the body element. 
@@ -17,7 +17,7 @@ The small bit of JavaScript calls in another JavaScript file, which can then do 
 * Change all the pictures to somethings else (offensive or not, its up to you). 
 * Display a modal saying the site has been stolen.
 
-###How to use it
+### How to use it
 Copy the safe file to somewhere you control.  
 Rename the domain part to the domain the kill switch is on. This is to stop accidental taking down of multiple sites.  
 Replace the safe file location in the top of the kill-switch.js with your safe file location.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
